### PR TITLE
Temporary fix to notification issue

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -35,17 +35,20 @@ defined('MOODLE_INTERNAL') || die();
 function paygw_duitku_before_footer() {
     global $USER, $DB;
 
-    $params = [
-        'userid' => (int)$USER->id,
-        'payment_status' => duitku_status_codes::CHECK_STATUS_PENDING
-    ];
-    $pendingtransactions = $DB->get_records_sql('SELECT * FROM {paygw_duitku} WHERE userid = :userid AND payment_status = :payment_status', $params);
-
-    foreach ($pendingtransactions as $transaction) {
-        $selectstatement = 'SELECT * FROM {course} INNER JOIN {enrol} ON {enrol}.courseid = {course}.id WHERE {enrol}.id = :itemid';
-        $params = ['itemid' => $transaction->itemid];
-        $course = $DB->get_records_sql($selectstatement, $params);
-        $message = "You have a pending payment for the '{$course[$transaction->itemid]->fullname}' course <a href='{$transaction->referenceurl}'>here</a>";
-        \core\notification::add($message, \core\output\notification::NOTIFY_WARNING);
+    $enabledplugins = \core\plugininfo\paygw::get_enabled_plugins();
+    if (!empty($enabledplugins['duitku'])) {
+        $params = [
+            'userid' => (int)$USER->id,
+            'payment_status' => duitku_status_codes::CHECK_STATUS_PENDING
+        ];
+        $pendingtransactions = $DB->get_records_sql('SELECT * FROM {paygw_duitku} WHERE userid = :userid AND payment_status = :payment_status', $params);
+    
+        foreach ($pendingtransactions as $transaction) {
+            $selectstatement = 'SELECT * FROM {course} INNER JOIN {enrol} ON {enrol}.courseid = {course}.id WHERE {enrol}.id = :itemid';
+            $params = ['itemid' => $transaction->itemid];
+            $course = $DB->get_records_sql($selectstatement, $params);
+            $message = "You have a pending payment for the '{$course[$transaction->itemid]->fullname}' course <a href='{$transaction->referenceurl}'>here</a>";
+            \core\notification::add($message, \core\output\notification::NOTIFY_WARNING);
+        }
     }
 }

--- a/lib.php
+++ b/lib.php
@@ -34,9 +34,8 @@ defined('MOODLE_INTERNAL') || die();
  */
 function paygw_duitku_before_footer() {
     global $USER, $DB;
-
     $enabledplugins = \core\plugininfo\paygw::get_enabled_plugins();
-    if (!empty($enabledplugins['duitku'])) {
+    if (array_key_exists('duitku', $enabledplugins)) {
         $params = [
             'userid' => (int)$USER->id,
             'payment_status' => duitku_status_codes::CHECK_STATUS_PENDING

--- a/templates/duitku_return_template.mustache
+++ b/templates/duitku_return_template.mustache
@@ -24,7 +24,6 @@
 
 	}
 }}
-
 <h2>{{return_header}}</h2>
 {{return_sub_header}}<br />
 {{{return_body}}}


### PR DESCRIPTION
For issue #8 
A Temporary fix to pending transaction issue. Will not enable the notification function if the plugin is disabled. This way it will not affect site performance if plugin is disabled.

A long term fix is to put pending transaction notification in the Messages section via Messages API