### PR TITLE
Format text for safety

### DIFF
--- a/return.php
+++ b/return.php
@@ -88,9 +88,9 @@ $a->teacher = get_string('defaultcourseteacher'); // Variable name must be $a, a
 $a->fullname = $fullname;// I have tried using other variable name than $a and it was not recognized.
 $a->reference = $referenceurl;
 $response = (object)[
-    'return_header' => get_string('return_header', 'paygw_duitku'),
-    'return_sub_header' => get_string('return_sub_header', 'paygw_duitku', $a),
-    'return_body' => get_string('return_body', 'paygw_duitku', $a)
+    'return_header' => format_text(get_string('return_header', 'paygw_duitku'), FORMAT_MOODLE),
+    'return_sub_header' => format_text(get_string('return_sub_header', 'paygw_duitku', $a), FORMAT_MOODLE),
+    'return_body' => format_text(get_string('return_body', 'paygw_duitku', $a), FORMAT_MOODLE)
 ];
 
 // Output reason why user has not been enrolled yet.


### PR DESCRIPTION
Every html format strings must be wrapped in format_text

Screenshot of return page.
![image](https://user-images.githubusercontent.com/74812824/178642859-b996382f-6daf-4ef7-be9c-97972c4ffbb2.png)
